### PR TITLE
Installation docs

### DIFF
--- a/src/docs/UserDocs/Docs01-Installing-Swate.md
+++ b/src/docs/UserDocs/Docs01-Installing-Swate.md
@@ -6,70 +6,23 @@ Author: Kevin Frey
 add toc: false
 add sidebar: _sidebars\mainSidebar.md
 ---
+<!-- 
+- [Browser](#browser)
+- [Desktop Installation via installer](#desktop-installation-via-installer)
+- [Manual Desktop Installation](#manual-desktop-installation)
+- [Organization-wide Desktop Installation](#organization-wide-desktop-installation) -->
 
-1. [Quickstart in Browser](#quickstart)
-2. [Desktop Installation](#desktop-installation)
-4. [Manual Installation](#manual-installation)
-3. [Using a shared folder as system admin](#using-a-shared-folder-as-system-admin)
 
-## Quickstart
+We currently offer different routes of installing Swate.
 
-If you want to jump right into Swate and start testing the environment and features without much fuzz, we recommend using Swate in the Browser. This method uses the web version of Microsoft Excel which can be used for free with an free Microsoft account.
+## Browser Installation
 
-1. Download the latest [swate-b-quickstart.zip](https://github.com/nfdi4plants/Swate/releases)
-2. Unzip (`Right click` → `Extract All..`)
-3. Navigate to the web version of [Excel](https://office.live.com/start/excel.aspx) and log in. Starting this up for the first time might take a minute.
-4. Open a (new) workbook, click `Insert` → `Office Add-ins`/`Add-ins` → `Upload My Add-in` and upload the `core_manifest.xml` from `swate-b-quickstart.zip`. 
-5. Go to `Data` and you should see the Swate.Core add-in. If not you might need to click on the three dots on the right side to expand your available options. 
-   
-![Swate.Core Icon](https://raw.githubusercontent.com/nfdi4plants/Branding/master/icons/Swate/Excel/Core/swate_c_48x48.png)
-
-6. Done! 🎉
-
+If you want to jump right into Swate and start testing the environment and features without much fuzz, we recommend using [Swate in your Browser](/docs/UserDocs/swate_installation_browser.html). This method uses the web version of Microsoft Excel which can be used for free with a free Microsoft account.
 
 ## Desktop Installation
 
-If you want to use Swate in your Excel desktop application, you can use the options below. If the provided installer does not work for you please try to use the [manual installation](#manual-installation).
+If you want to use Swate in your Excel desktop application, you can use the following options:
 
-⚠️ **If you have an older Swate version installed already, it <u>might</u> be necessary to [clear the cache](https://docs.microsoft.com/de-de/office/dev/add-ins/testing/clear-cache#manually-clear-the-cache-in-excel-word-and-powerpoint) to apply the changes to Swate.**
-
-- Download the [Windows Installer](https://github.com/nfdi4plants/Swate/blob/developer/.assets/swate-win.zip?raw=true). (MacOS-Installer coming soon™)
-- Close all Office instances (Excel, Powerpoint, Word, ...)
-- Unzip (`Right click` ➞ `Extract All..`)
-- Double click the `install.cmd`. You will be asked to give administrative permissions and in the end to allow changes to the registry. Allow both and you are good to go!
-- Open Excel, go to `Insert` ➞ `My Add-ins` ➞ `Shared Folder`. There you should see both `Swate` and `Swate.Experts`.
-
-<details><summary>Alternative | Using the previous Swate installer</summary>
-<p>
-
-[Swate installer](https://github.com/omaus/Swate_Install#swate-installer)
-
-</p>
-</details>
-
-<details><summary>Alternative | Using the release archive</summary>
-<p>
-    
-⚠️ This method might not be accessible anymore.
-
-Using the release archive
-
-- Install [node.js LTS](https://nodejs.org/en/) (needed for office addin related tooling)
-- Download the [latest test release archive](https://github.com/nfdi4plants/Swate/releases) and extract it
-- Execute the test.cmd (windows, as administrator) or test.sh (macOS, you will need to make it executable via chmod 
-a+x) script.
-  
-</p>
-</details>
-
-## Manual Installation
-
-Because of some legal roadblocks, we encountered as university trying to publish to the Excel add-in store, the current installer is far from perfect. Please use the below instructions to enable Swate for your Excel instance step-by-step.
-
-1. Download the latest [Swate manifests](https://github.com/nfdi4plants/Swate/blob/developer/.assets/swate-win.zip?raw=true)
-2. Follow the official microsoft docs to [sideload Swate in Excel](https://learn.microsoft.com/de-de/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins).
-3. You will need to add the `core_manifest.xml` (and optionally the `experts_manifest.xml`) to your shared folder.
-
-## Using a shared folder as system admin
-
-If you have administrative access in your organization, you can create a network share folder and follow [this guide](https://github.com/OfficeDev/office-js-docs-pr/blob/master/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md#:~:text=Sideload%20your%20add%2Din,-Put%20the%20manifest&text=Be%20sure%20to%20specify%20the,element%20of%20the%20manifest%20file.&text=In%20Excel%2C%20Word%2C%20or%20PowerPoint,Office%20Add%2Dins%20dialog%20box.) to make the addin available without any further downloads from your users.
+- [Desktop Installation via installer](/docs/UserDocs/swate_installation_desktop.html) :bulb: Recommended for **Windows** :bulb:
+- [Manual Desktop Installation](/docs/UserDocs/swate_installation_manual.html) :bulb: Recommended for **MacOS** :bulb: 
+- [Organization-wide Desktop Installation](/docs/UserDocs/swate_installation_organization.html) :bulb: Requires administrative access in your organization :bulb:

--- a/src/docs/UserDocs/swate_installation_browser.md
+++ b/src/docs/UserDocs/swate_installation_browser.md
@@ -1,0 +1,19 @@
+---
+layout: docs
+title: Swate Browser Installation 
+published: 2023-02-01
+add toc: false
+add sidebar: _sidebars\mainSidebar.md
+---
+
+1. Download the latest [swate-b-quickstart.zip](https://github.com/nfdi4plants/Swate/releases)
+2. Unzip (`Right click` → `Extract All..`)
+3. Navigate to the web version of [Excel](https://office.live.com/start/excel.aspx) and log in. Starting this up for the first time might take a minute.
+4. Open a (new) workbook, click `Insert` → `Office Add-ins`/`Add-ins` → `Upload My Add-in` and upload the `core_manifest.xml` from `swate-b-quickstart.zip`. 
+5. Go to `Data` and you should see the Swate.Core add-in. If not you might need to click on the three dots on the right side to expand your available options. 
+   
+![Swate.Core Icon](https://raw.githubusercontent.com/nfdi4plants/Branding/master/icons/Swate/Excel/Core/swate_c_48x48.png)
+
+6. Done! 🎉
+
+<!-- TODO: add browser recommendations -->

--- a/src/docs/UserDocs/swate_installation_desktop.md
+++ b/src/docs/UserDocs/swate_installation_desktop.md
@@ -1,0 +1,42 @@
+---
+layout: docs
+title: Swate Desktop Installation
+published: 2023-02-01
+add toc: false
+add sidebar: _sidebars\mainSidebar.md
+---
+
+> :warning: Currently there is no installer available for Linux or MacOS. Please check out the alternatives.
+
+> :bulb: As a university trying to publish to the Excel add-in store we encountered some legal roadblocks. Hence the current installer is far from perfect. Please check out the alternatives, if the installer does not work for your setup.
+
+> ⚠️ **If you have an older Swate version installed already, it <u>might</u> be necessary to [clear the cache](https://docs.microsoft.com/de-de/office/dev/add-ins/testing/clear-cache#manually-clear-the-cache-in-excel-word-and-powerpoint) to apply the changes to Swate.**
+
+- Download the [Windows Installer](https://github.com/nfdi4plants/Swate/blob/developer/.assets/swate-win.zip?raw=true).
+- Close all Office instances (Excel, Powerpoint, Word, ...)
+- Unzip (`Right click` ➞ `Extract All..`)
+- Double click the `install.cmd`. You will be asked to give administrative permissions and in the end to allow changes to the registry. Allow both and you are good to go!
+- Open Excel, go to `Insert` ➞ `My Add-ins` ➞ `Shared Folder`. There you should see both `Swate` and `Swate.Experts`.
+
+<details><summary>Alternative | Using the previous Swate installer</summary>
+<p>
+
+[Swate installer](https://github.com/omaus/Swate_Install#swate-installer)
+
+</p>
+</details>
+
+<details><summary>Alternative | Using the release archive</summary>
+<p>
+    
+⚠️ This method might not be accessible anymore.
+
+Using the release archive
+
+- Install [node.js LTS](https://nodejs.org/en/) (needed for office addin related tooling)
+- Download the [latest test release archive](https://github.com/nfdi4plants/Swate/releases) and extract it
+- Execute the test.cmd (windows, as administrator) or test.sh (macOS, you will need to make it executable via chmod 
+a+x) script.
+  
+</p>
+</details>

--- a/src/docs/UserDocs/swate_installation_manual.md
+++ b/src/docs/UserDocs/swate_installation_manual.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: Swate Manual Installation
+published: 2023-02-01
+add toc: false
+add sidebar: _sidebars\mainSidebar.md
+---
+
+1. Download the latest [Swate manifests](https://github.com/nfdi4plants/Swate/blob/developer/.assets/swate-win.zip?raw=true)
+2. Follow the official microsoft docs to [sideload Swate in Excel](https://learn.microsoft.com/de-de/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins).
+3. You will need to add the `core_manifest.xml` (and optionally the `experts_manifest.xml`) to your shared folder.

--- a/src/docs/UserDocs/swate_installation_manual_macos.md
+++ b/src/docs/UserDocs/swate_installation_manual_macos.md
@@ -1,0 +1,25 @@
+---
+layout: docs
+title: Swate Manual Installation for MacOS Excel Desktop
+published: 2023-02-01
+add toc: false
+add sidebar: _sidebars\mainSidebar.md
+---
+
+> Adapted from: https://learn.microsoft.com/en-us/office/dev/add-ins/testing/sideload-an-office-add-in-on-mac
+
+## Prerequisites
+
+- A Mac running OS X v10.10 "Yosemite" or later with Office on Mac installed.
+- Excel on Mac version 15.19 (160206).
+
+## Steps
+
+1. Download the latest [Swate manifests](https://github.com/nfdi4plants/Swate/blob/developer/.assets/swate-win.zip?raw=true)
+2. Open a Finder and hit &#8984;+&#8679;+G (or via menu: Go -> "Go to Folder...") to open the "Go to Folder..." dialog
+3. Navigate to `/Users/<username>/Library/Containers/com.microsoft.Excel/Data/Documents/` (replace <username> with your user name on the computer)
+4. (If it does not exit, create and) open the folder `wef`
+5. Add the files `core_manifest.xml` (and optionally the `experts_manifest.xml`) downloaded in step 1 to the folder `wef`.
+6. Open a fresh Workbook in Excel, go to the `Insert` tab. 
+7. Click the arrow next to `My Add-ins`. There you should be able to select `Swate` (and optionally `Swate.Experts`).
+8. Once selected, Swate appears in the `Data` tab. ![Swate.Core Icon](https://raw.githubusercontent.com/nfdi4plants/Branding/master/icons/Swate/Excel/Core/swate_c_48x48.png)

--- a/src/docs/UserDocs/swate_installation_organization.md
+++ b/src/docs/UserDocs/swate_installation_organization.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: Swate Organization-wide Installation
+published: 2023-02-01
+add toc: false
+add sidebar: _sidebars\mainSidebar.md
+---
+
+## Using a shared folder as system admin
+
+If you have administrative access in your organization, you can create a network share folder and follow [this guide](https://github.com/OfficeDev/office-js-docs-pr/blob/master/docs/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins.md#:~:text=Sideload%20your%20add%2Din,-Put%20the%20manifest&text=Be%20sure%20to%20specify%20the,element%20of%20the%20manifest%20file.&text=In%20Excel%2C%20Word%2C%20or%20PowerPoint,Office%20Add%2Dins%20dialog%20box.) to make the addin available without any further downloads from your users.

--- a/src/docs/_sidebars/mainSidebar.md
+++ b/src/docs/_sidebars/mainSidebar.md
@@ -6,6 +6,11 @@ Article Status: Publishable
 ```Feature Documentation
 # Home:/index.html
 # 1. Installing Swate:/docs/UserDocs/Docs01-Installing-Swate.html
+## Browser:/docs/UserDocs/swate_installation_browser.html
+## Desktop:/docs/UserDocs/swate_installation_desktop.html
+## Manual:/docs/UserDocs/swate_installation_manual.html
+### MacOS:/docs/UserDocs/swate_installation_manual_macos.html
+## Organization-wide:/docs/UserDocs/swate_installation_organization.html
 # 2. Annotation tables:/docs/UserDocs/Docs02-Annotation-Table.html
 # 3. Building blocks:/docs/UserDocs/Docs03-Building-Blocks.html
 # 4. Filling cells with ontology terms:/docs/UserDocs/Docs04-Ontology-Term-Search.html


### PR DESCRIPTION
broke down installation manual into multiple subs 
idea: easier to find and link to the individually relevant solution (especially MacOS was fairly hidden) 